### PR TITLE
fix unit tests

### DIFF
--- a/test/BallotboxSpec.scala
+++ b/test/BallotboxSpec.scala
@@ -75,7 +75,7 @@ class BallotboxSpec extends Specification with TestContexts with Response {
 
             // for validation to work we need to set the pk for the election manually (for election 1020)
             Elections.setPublicKeys(1, pks1020)
-            Elections.updateState(1, Elections.REGISTERED, Elections.STARTED)
+            Elections.updateState(1, Elections.CREATED, Elections.STARTED)
           }
         )
       }
@@ -99,7 +99,7 @@ class BallotboxSpec extends Specification with TestContexts with Response {
 
         // for validation to work we need to set the pk for the election manually (for election 1020)
         Elections.setPublicKeys(1, pks1020)
-        Elections.updateState(1, Elections.REGISTERED, Elections.STARTED)
+        Elections.updateState(1, Elections.CREATED, Elections.STARTED)
       }
 
       val voteJson = getVote(1, "1")

--- a/test/BallotboxSpec.scala
+++ b/test/BallotboxSpec.scala
@@ -71,7 +71,7 @@ class BallotboxSpec extends Specification with TestContexts with Response {
           errors => failure(s"Invalid election config json $errors"),
 
           cfg => {
-            Elections.insert(Election(cfg.id, TestData.config.toString, Elections.REGISTERED, cfg.start_date, cfg.end_date, None, None, None, None, None, None, false, true, None))
+            Elections.insert(Election(cfg.id, TestData.config.toString, Elections.CREATED, cfg.start_date, cfg.end_date, None, None, None, None, None, None, false, true, None))
 
             // for validation to work we need to set the pk for the election manually (for election 1020)
             Elections.setPublicKeys(1, pks1020)
@@ -95,7 +95,7 @@ class BallotboxSpec extends Specification with TestContexts with Response {
 
       DB.withSession { implicit session =>
         val cfg = TestData.config.validate[ElectionConfig].get
-        Elections.insert(Election(cfg.id, TestData.config.toString, Elections.REGISTERED, cfg.start_date, cfg.end_date, None, None, None, None, None, None, false, false, None))
+        Elections.insert(Election(cfg.id, TestData.config.toString, Elections.CREATED, cfg.start_date, cfg.end_date, None, None, None, None, None, None, false, false, None))
 
         // for validation to work we need to set the pk for the election manually (for election 1020)
         Elections.setPublicKeys(1, pks1020)


### PR DESCRIPTION
Inadvertently, the merge of https://github.com/agoravoting/agora_elections/pull/102 for support for start/stop and halt/resume feature broke the unit tests. This PR fixes that.