### PR TITLE
Fixing tally sheets replacement

### DIFF
--- a/app/controllers/ElectionsApi.scala
+++ b/app/controllers/ElectionsApi.scala
@@ -538,15 +538,17 @@ object ElectionsApi
 
         val config =
           if (election.ballotBoxesResultsConfig.isDefined)
-            configBase.replaceAll(
-              "__ballotBoxesResultsConfig__",
-              election.ballotBoxesResultsConfig.get
-            )
+            configBase
+              .replaceAll(
+                "\"__ballotBoxesResultsConfig__\"",
+                election.ballotBoxesResultsConfig.get
+              )
           else
-            configBase.replaceAll(
-              "__ballotBoxesResultsConfig__",
-              "[]"
-            )
+            configBase
+              .replaceAll(
+                "\"__ballotBoxesResultsConfig__\"",
+                "[]"
+              )
 
         // ensure a tally can be executed
         ensureTally(id, election)


### PR DESCRIPTION
When using tally sheets, currently the tally sheets are replaced in the results-config using the `__ballotBoxesResultsConfig__` placeholder, but that makes the results-config invalid json. Instead, the placeholder will be now `"__ballotBoxesResultsConfig__"`.