### PR TITLE
dumpTheVotes() was not filtering inactive voters

### DIFF
--- a/app/controllers/BallotboxApi.scala
+++ b/app/controllers/BallotboxApi.scala
@@ -216,7 +216,8 @@ INNER JOIN api_userdata ON api_acl.user_id = api_userdata.id
 INNER JOIN auth_user ON auth_user.id = api_userdata.user_id
 INNER JOIN api_authevent ON api_authevent.id = '$electionId'
 WHERE 
-  api_acl.object_id IS NOT NULL 
+  auth_user.is_active = true
+  AND api_acl.object_id IS NOT NULL
   AND api_acl.object_type = 'AuthEvent'
   AND api_acl.perm = 'vote'
   AND (


### PR DESCRIPTION
When votes are dumped in order to launch a tally, sometimes these votes are requested to be dumped filtering out deactivated voters, i.e. those voters with is_active=False in the auth_user database User table.

In that case, we were not removing inactive voters, so basically all votes corresponding to registered votes were always being dumped for tallying, even if this was not requested action.

This error was most probably introduced when the optimization on vote dumping was added by filtering using a hand-crafted SQL query and then filtering with the join command around 14 months ago.