### PR TITLE
Fix race conditions with `Cache.remove` and changes in the DB

### DIFF
--- a/app/models/DAL.scala
+++ b/app/models/DAL.scala
@@ -126,8 +126,11 @@ object DAL {
       }
       case None => {
         val election = Elections.findById(id)
-        // set in cache if found
-        election.map(Cache.set(key(id), _))
+        // set in cache if found, with some expiration
+        val expirationSeconds = Play.current.configuration
+          .getInt("app.cache.expiration_seconds")
+          .getOrElse(60)
+        election.map(Cache.set(key(id), _, expirationSeconds))
         election
       }
     }
@@ -137,33 +140,39 @@ object DAL {
     }
 
     def insert(election: Election) = DB.withSession { implicit session =>
+      val ret = Elections.insert(election)
       Cache.remove(key(election.id))
-      Elections.insert(election)
+      ret
     }
 
     def update(id: Long, election: Election) = DB.withSession { implicit session =>
+      val ret = Elections.update(id, election)
       Cache.remove(key(id))
-      Elections.update(id, election)
+      ret
     }
 
     def setStartDate(id: Long, startDate: Timestamp) = DB.withSession { implicit session =>
+      val ret = Elections.setStartDate(id, startDate)
       Cache.remove(key(id))
-      Elections.setStartDate(id, startDate)
+      ret
     }
 
     def setStopDate(id: Long, endDate: Timestamp) = DB.withSession { implicit session =>
+      val ret = Elections.setStopDate(id, endDate)
       Cache.remove(key(id))
-      Elections.setStopDate(id, endDate)
+      ret
     }
 
     def setTallyDate(id: Long, tallyDate: Timestamp) = DB.withSession { implicit session =>
+      val ret = Elections.setTallyDate(id, tallyDate)
       Cache.remove(key(id))
-      Elections.setTallyDate(id, tallyDate)
+      ret
     }
 
     def insertWithSession(election: Election)(implicit s:Session) = DB.withSession { implicit session =>
+      val ret = Elections.insert(election)
       Cache.remove(key(election.id))
-      Elections.insert(election)
+      ret
     }
 
     def updateState(id: Long, state: String) = DB.withSession { implicit session =>
@@ -172,39 +181,45 @@ object DAL {
         .findByIdWithSession(id)
         .get
         .state
+      val ret = Elections.updateState(id, current_state, state)
       Cache.remove(key(id))
-      Elections.updateState(id, current_state, state)
+      ret
     }
 
     def allowTally(id: Long) = DB.withSession { implicit session =>
+      val ret = Elections.allowTally(id)
       Cache.remove(key(id))
-      Elections.allowTally(id)
+      ret
     }
 
     def updatePublishedResults(id: Long, results: String) = DB.withSession { implicit session =>
-      Cache.remove(key(id))
+      val ret = Cache.remove(key(id))
       Elections.updatePublishedResults(id, results)
+      ret
     }
 
     def updateResults(id: Long, results: String, updateStatus: Boolean) = DB.withSession { implicit session =>
+      val ret = Elections.updateResults(id, results, updateStatus)
       Cache.remove(key(id))
-      Elections.updateResults(id, results, updateStatus)
+      ret
     }
 
     def updateBallotBoxesResultsConfig(id: Long, config: String)
     = DB.withSession
     {
       implicit session =>
+        val ret = Elections.updateBallotBoxesResultsConfig(id, config)
         Cache.remove(key(id))
-        Elections.updateBallotBoxesResultsConfig(id, config)
+        ret
     }
 
     def updateResultsConfig(id: Long, config: String)
     = DB.withSession
     {
       implicit session =>
+        val ret = Elections.updateResultsConfig(id, config)
         Cache.remove(key(id))
-        Elections.updateResultsConfig(id, config)
+        ret
     }
 
     def updateConfig(
@@ -215,18 +230,21 @@ object DAL {
     ) = DB.withSession 
     { 
       implicit session =>
+        val ret = Elections.updateConfig(id, config, start, end)
         Cache.remove(key(id))
-        Elections.updateConfig(id, config, start, end)
+        ret
     }
 
     def setPublicKeys(id: Long, pks: String) = DB.withSession { implicit session =>
+      val ret = Elections.setPublicKeys(id, pks)
       Cache.remove(key(id))
-      Elections.setPublicKeys(id, pks)
+      ret
     }
 
     def delete(id: Long) = DB.withSession { implicit session =>
+      val ret = Elections.delete(id)
       Cache.remove(key(id))
-      Elections.delete(id)
+      ret
     }
 
     private def key(id: Long) = s"election.$id"

--- a/conf/application.test.conf
+++ b/conf/application.test.conf
@@ -50,6 +50,7 @@ app.download_tally_timeout=10
 app.download_tally_retries=10
 app.callbacks.started="hohoho"
 app.partial-tallies=false
+app.cache.expiration_seconds=60
 
 elections.auth.secret=hohoho
 elections.auth.expiry=600000


### PR DESCRIPTION
Fix race conditions with `Cache.remove` and changes in the DB. In code like this (from DAL.scala):

 ```scala
def updateState(id: Long, state: String) = DB.withSession { implicit session =>
      val current_state = DAL
        .elections
        .findByIdWithSession(id)
        .get
        .state
      Cache.remove(key(id))
      Elections.updateState(id, current_state, state)
    }
```

If between the cache.remove() call and Elections.updateState() there's another get request of the election executed, then the cache will have an outdated version of the election state. This has happened during a tally. The tally got stopped until we restarted `memcached`and `ballot-box`. We need to review that all the cache invalidation code executes only after the database has been updated. 

Also, just in case the cache will now have an expiration time of.. around 60 seconds using the setting `app.cache.expiration_seconds`. The expiration time is a second way of fixing this bug: it would have meant a (by default) 60 seconds delay in the tally, which might have not even gone noticed.